### PR TITLE
修正了邮件模板中没有统一格式的标点

### DIFF
--- a/template/default/send.ejs
+++ b/template/default/send.ejs
@@ -4,7 +4,7 @@
             <%=siteName%>
             </a>上的评论有了新的回复
     </h2> 
-    { <%=pname%> } 同学, 您曾发表评论:
+    { <%=pname%> } 同学，您曾发表评论：
     <div style="padding:0 12px 0 12px;margin-top:18px">
         <div style="background-color: #f5f5f5;padding: 10px 15px;margin:18px 0;word-wrap:break-word;">
             <%-ptext%>
@@ -13,7 +13,7 @@
         <div style="background-color: #f5f5f5;padding: 10px 15px;margin:18px 0;word-wrap:break-word;">
             <%-text%>
         </div>
-        <p>您可以点击<a style="text-decoration:none; color:#12addb" href="<%=url%>#comments" target="_blank">查看回复的完整內容 </a>, 欢迎再次光临 <a style="text-decoration:none; color:#12addb" 
+        <p>您可以点击<a style="text-decoration:none; color:#12addb" href="<%=url%>#comments" target="_blank">查看回复的完整內容 </a>，欢迎再次光临 <a style="text-decoration:none; color:#12addb" 
             href="<%=siteUrl%>" target="_blank"><%=siteName%></a>。
             <br>
             本邮件为系统自动发送，请勿直接回复。

--- a/template/rainbow/notice.ejs
+++ b/template/rainbow/notice.ejs
@@ -19,7 +19,7 @@
         <p style="font-size:15px;word-break:break-all;padding: 23px 32px;margin:0;background-color: hsla(0,0%,100%,.4);border-radius: 10px 10px 0 0;">您的<a style="text-decoration:none;color: #ffffff;" href="<%=siteUrl%>"> <%=siteName%> </a>上有新的评论啦！ </p> 
        </div> 
        <div style="margin:40px auto;width:90%"> 
-        <p><%=name%> 发表评论:</p> 
+        <p><%=name%> 发表评论：</p> 
         <div style="background: #fafafa repeating-linear-gradient(-45deg,#fff,#fff 1.125rem,transparent 1.125rem,transparent 2.25rem);box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);margin:20px 0px;padding:15px;border-radius:5px;font-size:14px;color:#555555;"><%-text%></div> 
         <p><a style="text-decoration:none; color:#12addb" href="<%=url%>#comments" target="_blank">[查看评论]</a></p> 
         <style type="text/css">a:link{text-decoration:none}a:visited{text-decoration:none}a:hover{text-decoration:none}a:active{text-decoration:none}</style> 

--- a/template/rainbow/send.ejs
+++ b/template/rainbow/send.ejs
@@ -10,7 +10,7 @@
         <p style="font-size:15px;word-break:break-all;padding: 23px 32px;margin:0;background-color: hsla(0,0%,100%,.4);border-radius: 10px 10px 0 0;">您在<a style="text-decoration:none;color: #ffffff;" href="<%=siteUrl%>"> <%=siteName%> </a>上的留言有新回复啦！ </p> 
        </div> 
        <div style="margin:40px auto;width:90%"> 
-        <p><%=pname%> 同学，您曾在文章上发表评论:</p> 
+        <p><%=pname%> 同学，您曾在文章上发表评论：</p> 
         <div style="background: #fafafa repeating-linear-gradient(-45deg,#fff,#fff 1.125rem,transparent 1.125rem,transparent 2.25rem);box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);margin:20px 0px;padding:15px;border-radius:5px;font-size:14px;color:#555555;"><%-ptext%></div> 
         <p><%=name%> 给您的回复如下：</p> 
         <div style="background: #fafafa repeating-linear-gradient(-45deg,#fff,#fff 1.125rem,transparent 1.125rem,transparent 2.25rem);box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);margin:20px 0px;padding:15px;border-radius:5px;font-size:14px;color:#555555;"><%-text%></div> 


### PR DESCRIPTION
邮件模板中部分的标点采用了「半角标点」，另外的一些是「全角标点」，既然是中文邮件模板，就统一改成全角标点符号吧，看起来美观一些。