### PR TITLE
添加Github风格邮件主题样式

### DIFF
--- a/template/github/notice.ejs
+++ b/template/github/notice.ejs
@@ -1,0 +1,51 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title><%=siteName%>有新的回复</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+
+<body>
+    <table style="width: 500px;height:99.8%;background-color: #ffffff;margin-top:40px;margin-left: auto;margin-right:auto;padding-left:20px;padding-right:20px">
+        <tr>
+            <td style="text-align:center">
+                <h1 style="margin-bottom: 0px; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em">
+                    <%=siteName%>
+                </h1>
+            </td>
+        </tr>
+        <tr>
+            <td style="text-align:left">
+                <p style="margin-top: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">您收到了新的评论</p>
+                <p style="margin-bottom: 16px"><%=name%> 发表评论：</p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <table>
+                    <tr>
+                        <td style="background-color:#DFE2E5;padding-left:3px;">
+                        </td>
+                        <td style="padding-left:14px"></td>
+                        <td>
+                            <p style="color:rgb(119, 119, 119);margin-top:0;margin-bottom:0">
+                                <%-text%>
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <p style="margin-top:16px">
+                    <a href="<%=url%>#comments" style="text-decoration: none">[查看评论]</a>
+                </p>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/template/github/notice.ejs
+++ b/template/github/notice.ejs
@@ -18,8 +18,7 @@
         </tr>
         <tr>
             <td style="text-align:left">
-                <p style="margin-top: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">您收到了新的评论</p>
-                <p style="margin-bottom: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol"><%=name%> 发表评论：</p>
+                <p style="margin-top: 16px; margin-bottom: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">您收到了来自<%=name%>的评论：</p>
             </td>
         </tr>
         <tr>
@@ -41,7 +40,7 @@
         <tr>
             <td>
                 <p style="margin-top:16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">
-                    <a href="<%=url%>#comments" style="text-decoration: none">[查看评论]</a>
+                    <a href="<%=url%>#comments" style="text-decoration: none">点此</a>查看评论
                 </p>
             </td>
         </tr>

--- a/template/github/notice.ejs
+++ b/template/github/notice.ejs
@@ -11,7 +11,7 @@
     <table style="width: 500px;height:99.8%;background-color: #ffffff;margin-top:40px;margin-left: auto;margin-right:auto;padding-left:20px;padding-right:20px">
         <tr>
             <td style="text-align:center">
-                <h1 style="margin-bottom: 0px; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em">
+                <h1 style="margin-bottom: 0px; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em; font-size: 2em;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">
                     <%=siteName%>
                 </h1>
             </td>

--- a/template/github/notice.ejs
+++ b/template/github/notice.ejs
@@ -19,7 +19,7 @@
         <tr>
             <td style="text-align:left">
                 <p style="margin-top: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">您收到了新的评论</p>
-                <p style="margin-bottom: 16px"><%=name%> 发表评论：</p>
+                <p style="margin-bottom: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol"><%=name%> 发表评论：</p>
             </td>
         </tr>
         <tr>
@@ -30,7 +30,7 @@
                         </td>
                         <td style="padding-left:14px"></td>
                         <td>
-                            <p style="color:rgb(119, 119, 119);margin-top:0;margin-bottom:0">
+                            <p style="color:rgb(119, 119, 119);margin-top:0;margin-bottom:0; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">
                                 <%-text%>
                             </p>
                         </td>
@@ -40,7 +40,7 @@
         </tr>
         <tr>
             <td>
-                <p style="margin-top:16px">
+                <p style="margin-top:16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">
                     <a href="<%=url%>#comments" style="text-decoration: none">[查看评论]</a>
                 </p>
             </td>

--- a/template/github/send.ejs
+++ b/template/github/send.ejs
@@ -19,7 +19,7 @@
         <tr>
             <td style="text-align:left">
                 <p style="margin-top: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">您收到了新的评论</p>
-                <p style="margin-bottom: 16px"><%=pname%> 同学，您曾在文章上发表评论：</p>
+                <p style="margin-bottom: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol"><%=pname%> 同学，您曾在文章上发表评论：</p>
             </td>
         </tr>
         <tr>
@@ -30,7 +30,7 @@
                         </td>
                         <td style="padding-left:14px"></td>
                         <td>
-                            <p style="color:rgb(119, 119, 119);margin-top:0;margin-bottom:0">
+                            <p style="color:rgb(119, 119, 119);margin-top:0;margin-bottom:0; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">
                                 <%-ptext%>
                             </p>
                         </td>
@@ -41,7 +41,7 @@
         <tr>
             <td style="text-align:left">
                 <p style="margin-top: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">您收到了新的评论</p>
-                <p style="margin-bottom: 16px"><%=name%> 给您的回复如下：</p>
+                <p style="margin-bottom: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol"><%=name%> 给您的回复如下：</p>
             </td>
         </tr>
         <tr>
@@ -52,7 +52,7 @@
                         </td>
                         <td style="padding-left:14px"></td>
                         <td>
-                            <p style="color:rgb(119, 119, 119);margin-top:0;margin-bottom:0">
+                            <p style="color:rgb(119, 119, 119);margin-top:0;margin-bottom:0; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">
                                 <%-text%>
                             </p>
                         </td>
@@ -62,7 +62,7 @@
         </tr>
         <tr>
             <td>
-                <p style="margin-top:16px">
+                <p style="margin-top:16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">
                     您可以点击<a href="<%=url%>#comments" style="text-decoration: none">查看回复的完整内容</a>，欢迎再次光临<a href="<%=siteUrl%>" style="text-decoration: none"><%=siteName%></a>
                 </p>
             </td>

--- a/template/github/send.ejs
+++ b/template/github/send.ejs
@@ -1,0 +1,73 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title><%=siteName%>有新的回复</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+
+<body>
+    <table style="width: 500px;height:99.8%;background-color: #ffffff;margin-top:40px;margin-left: auto;margin-right:auto;padding-left:20px;padding-right:20px">
+        <tr>
+            <td style="text-align:center">
+                <h1 style="margin-bottom: 0px; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em">
+                    <%=siteName%>
+                </h1>
+            </td>
+        </tr>
+        <tr>
+            <td style="text-align:left">
+                <p style="margin-top: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">您收到了新的评论</p>
+                <p style="margin-bottom: 16px"><%=pname%> 同学，您曾在文章上发表评论：</p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <table>
+                    <tr>
+                        <td style="background-color:#DFE2E5;padding-left:3px;">
+                        </td>
+                        <td style="padding-left:14px"></td>
+                        <td>
+                            <p style="color:rgb(119, 119, 119);margin-top:0;margin-bottom:0">
+                                <%-ptext%>
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <tr>
+            <td style="text-align:left">
+                <p style="margin-top: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">您收到了新的评论</p>
+                <p style="margin-bottom: 16px"><%=name%> 给您的回复如下：</p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <table>
+                    <tr>
+                        <td style="background-color:#DFE2E5;padding-left:3px;">
+                        </td>
+                        <td style="padding-left:14px"></td>
+                        <td>
+                            <p style="color:rgb(119, 119, 119);margin-top:0;margin-bottom:0">
+                                <%-text%>
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <p style="margin-top:16px">
+                    您可以点击<a href="<%=url%>#comments" style="text-decoration: none">查看回复的完整内容</a>，欢迎再次光临<a href="<%=siteUrl%>" style="text-decoration: none"><%=siteName%></a>
+                </p>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/template/github/send.ejs
+++ b/template/github/send.ejs
@@ -18,7 +18,6 @@
         </tr>
         <tr>
             <td style="text-align:left">
-                <p style="margin-top: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">您收到了新的评论</p>
                 <p style="margin-bottom: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol"><%=pname%> 同学，您曾在文章上发表评论：</p>
             </td>
         </tr>
@@ -40,7 +39,6 @@
         </tr>
         <tr>
             <td style="text-align:left">
-                <p style="margin-top: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">您收到了新的评论</p>
                 <p style="margin-bottom: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol"><%=name%> 给您的回复如下：</p>
             </td>
         </tr>

--- a/template/github/send.ejs
+++ b/template/github/send.ejs
@@ -11,7 +11,7 @@
     <table style="width: 500px;height:99.8%;background-color: #ffffff;margin-top:40px;margin-left: auto;margin-right:auto;padding-left:20px;padding-right:20px">
         <tr>
             <td style="text-align:center">
-                <h1 style="margin-bottom: 0px; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em">
+                <h1 style="margin-bottom: 0px; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em; font-size: 2em;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol">
                     <%=siteName%>
                 </h1>
             </td>

--- a/template/github/send.ejs
+++ b/template/github/send.ejs
@@ -18,7 +18,7 @@
         </tr>
         <tr>
             <td style="text-align:left">
-                <p style="margin-bottom: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol"><%=pname%> 同学，您曾在文章上发表评论：</p>
+                <p style="margin-top: 16px;margin-bottom: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol"><%=pname%> 同学，您曾在文章上发表评论：</p>
             </td>
         </tr>
         <tr>
@@ -39,7 +39,7 @@
         </tr>
         <tr>
             <td style="text-align:left">
-                <p style="margin-bottom: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol"><%=name%> 给您的回复如下：</p>
+                <p style="margin-top: 16px;margin-bottom: 16px; font-size:16px; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol"><%=name%> 给您的回复如下：</p>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
你好呀，这是我自己做的Github风格的邮件主题。最主要的特点是可以兼容一些第三方邮件客户端。

# 效果
## QQmail
**站长收到的评论通知邮件：**
![qqmail](https://user-images.githubusercontent.com/41894967/52850383-508ae200-314e-11e9-8e2e-41868af45106.PNG)
**游客收到的回复通知邮件：**
![qqmail](https://user-images.githubusercontent.com/41894967/52850411-64364880-314e-11e9-80cd-f076a98240b0.PNG)
## QQmail和win10 UWP mail对比
**QQmail：**
![qqmail](https://user-images.githubusercontent.com/41894967/52850452-7b753600-314e-11e9-8640-f02763dfbe74.PNG)
**win10 UWP mail：**
![win10mail](https://user-images.githubusercontent.com/41894967/52850459-7fa15380-314e-11e9-9fba-b7e2c8ccdef0.PNG)

# 制作动机
我发现win10 UWP mail渲染不出default和rainbow主题，显示出来的界面要么空白要么不正常
后来才知道mail 3rd client对html的渲染很谨慎，往往会扔掉很多元素
此时XHTML 1.0 Strict是兼容性最好的标准
我并不擅长html，所以按这个标准做了个简单的Github风格主题，使其在一些client上可以被显示

# 其他
目前已经测试过：
* win10 mail
* QQ邮箱
* 新浪邮箱
* Gmail

其他就没有测试了。
P.S. 有邮件客户端测试平台，不过没有免费的；即使是试用，也要让你填银行卡信息；我时间也不甚多。所以就没做其他平台的测试

