### PR TITLE
修复无法部署的错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "nodemon": "^1.11.0"
   },
   "engines": {
-    "node": "6.x"
+    "node": "12.x"
   }
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/11037722/79484865-e8cc7180-8046-11ea-9664-dc98281e3971.png)

LeanCloud 已经不支持 node.js 6.* 的部署。

更新了 package.json 中的 node.js 版本号。