### PR TITLE
添加 FROM_EMAIL 变量，修复无法使用 SES 发送的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 * `SMTP_PASS` : SMTP 密码，一般为授权码，而不是邮箱的登陆密码，请自行查询对应邮件服务商的获取方式
 * `SMTP_SERVICE` : 邮件服务提供商，支持 `QQ`、`163`、`126`、`Gmail`、`"Yahoo"`、`......`  ，全部支持请参考 : [Nodemailer Supported services](https://nodemailer.com/smtp/well-known/#supported-services)。 --- *如这里没有你使用的邮件提供商，请查看[自定义邮件服务器](/高级配置.md#自定义邮件服务器)*
 * `SENDER_NAME` : 寄件人名称。
+* `FROM_EMAIL` : 寄件人邮箱地址。
 
 ## 高级配置
 

--- a/utilities/send-mail.js
+++ b/utilities/send-mail.js
@@ -44,7 +44,7 @@ exports.notice = (comment) => {
                         });
 
     let mailOptions = {
-        from: '"' + process.env.SENDER_NAME + '" <' + process.env.SMTP_USER + '>',
+        from: '"' + process.env.SENDER_NAME + '" <' + process.env.FROM_EMAIL + '>',
         to: process.env.TO_EMAIL ? process.env.TO_EMAIL : process.env.SMTP_USER,
         subject: emailSubject,
         html: emailContent
@@ -81,7 +81,7 @@ exports.send = (currentComment, parentComment)=> {
                             url: process.env.SITE_URL + currentComment.get('url') + "#" + currentComment.get('pid')
                         });
     let mailOptions = {
-        from: '"' + process.env.SENDER_NAME + '" <' + process.env.SMTP_USER + '>',
+        from: '"' + process.env.SENDER_NAME + '" <' + process.env.FROM_EMAIL + '>',
         to: parentComment.get('mail'),
         subject: emailSubject,
         html: emailContent


### PR DESCRIPTION
Amazon SES 服务的 `SMTP_USER` 和 `FROM_EMAIL` 不一致，需要单独设置。